### PR TITLE
Add functionality for exposing container ports on an external host

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,10 @@ locals {
         "awslogs-stream-prefix" : "container"
       }
     }
+    portMappings = [for mapping in var.task_port_mappings : {
+      containerPort = mapping.container
+      hostPort      = mapping.host
+    }]
     command     = var.task_container_command
     healthCheck = var.task_container_health_check
     environment = local.task_environment

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,15 @@ variable "task_container_image" {
   type        = string
 }
 
+variable "task_port_mappings" {
+  description = "An optional list of container ports to expose on the external host."
+  type = list(object({
+    host      = number
+    container = number
+  }))
+  default = []
+}
+
 variable "desired_count" {
   description = "The number of instances of the task definitions to place and keep running."
   default     = 1


### PR DESCRIPTION
The default behavior is to not expose any ports on the external host. The changes introduced in this PR allows a user of the module to expose one or multiple container ports on the external host's network.