### PR TITLE
Output ARNs of SNS Alarm topics

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,11 @@ output "task_execution_role" {
 output "task_role" {
   value = aws_iam_role.task.name
 }
+
+output "critical_alarm_topic_arn" {
+  value = aws_sns_topic.critical_alarms.arn
+}
+
+output "degraded_alarm_topic_arn" {
+  value = aws_sns_topic.degraded_alarms.arn
+}


### PR DESCRIPTION
Output the ARNs of the Alarm Topics created by module so that its possiblee to add custom alarms to them.